### PR TITLE
Use GITHUB_TOKEN in Zola deploy workflow

### DIFF
--- a/.github/workflows/zola-builder.yml
+++ b/.github/workflows/zola-builder.yml
@@ -1,5 +1,8 @@
 name: Zola Build and Push
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [ main ]
@@ -16,5 +19,5 @@ jobs:
         env:
           # Target branch
           PAGES_BRANCH: gh-pages
-          # Provide personal access token
-          TOKEN: ${{ secrets.TOKEN }}
+          # Use GitHub-provided workflow token
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- switch the deploy action token from a custom `TOKEN` secret to the built-in `GITHUB_TOKEN`
- add workflow permissions (`contents: write`) so the workflow token can push to `gh-pages`
- keep the deployment behavior the same while removing the need for a manual PAT secret